### PR TITLE
Return proper cid string from embed methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Symfony mailer extension Change Log
 2.0.2 under development
 -----------------------
 
-- Bug #15: Fix return value of Message::embed() and Message::embedContent()
+- Bug #15: Fix return value of Message::embed() and Message::embedContent() (Hyncica)
 
 
 2.0.1 December 31, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Symfony mailer extension Change Log
 2.0.2 under development
 -----------------------
 
-- no changes in this release.
+- Bug #15: Fix return value of Message::embed() and Message::embedContent()
 
 
 2.0.1 December 31, 2021

--- a/src/Message.php
+++ b/src/Message.php
@@ -237,7 +237,7 @@ final class Message extends BaseMessage
         }
 
         $this->email->embedFromPath($fileName, $file['name'], $file['contentType']);
-        return $this;
+        return 'cid:' . $file['name'];
     }
 
     /**
@@ -259,7 +259,7 @@ final class Message extends BaseMessage
         }
 
         $this->email->embed($content, $file['name'], $file['contentType']);
-        return $this;
+        return 'cid:' . $file['name'];
     }
 
     public function getHeader(string $name): array

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -260,6 +260,8 @@ class MessageTest extends TestCase
         $message = $this->createTestMessage();
 
         $cid = $message->embed($fileName);
+        $this->assertIsString($cid);
+        $this->assertStringStartsWith('cid:', $cid);
         $message->setTo($this->testEmailReceiver);
         $message->setFrom('someuser@somedomain.com');
         $message->setSubject('Yii Symfony Embed File Test');
@@ -286,6 +288,8 @@ class MessageTest extends TestCase
         $fileContent = file_get_contents($fileFullName);
 
         $cid = $message->embedContent($fileContent, ['fileName' => $fileName, 'contentType' => $contentType]);
+        $this->assertIsString($cid);
+        $this->assertStringStartsWith('cid:', $cid);
 
         $message->setTo($this->testEmailReceiver);
         $message->setFrom('someuser@somedomain.com');


### PR DESCRIPTION
Based on symfony/mailer docs the cid should be value of second
 parameter of embed() or embedFromPath() method call.

Added assertions to testEmbedFile() and testEmbedContent() that
checks if the returned value is string that starts with 'cid:'.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #15 
