### PR TITLE
Fix #17: Fix missing import for `\RuntimeException` in `Mailer`, Fix …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Yii Framework 2 Symfony mailer extension Change Log
 
 - Bug #15: Fix return value of Message::embed() and Message::embedContent() (Hyncica)
 - Bug #17: Fix missing import for `\RuntimeException` in `Mailer` (samdark)
-- Bug: Fix `Message` incompatibility with `MessageInterface` (samdark)
-- Bug: Fix not calling `Message` constructor (samdark)
+- Bug #18: Fix `Message` incompatibility with `MessageInterface` (samdark)
+- Bug #18: Fix not calling `Message` constructor (samdark)
 
 2.0.1 December 31, 2021
 -----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Yii Framework 2 Symfony mailer extension Change Log
 -----------------------
 
 - Bug #15: Fix return value of Message::embed() and Message::embedContent() (Hyncica)
-
+- Bug #17: Fix missing import for `\RuntimeException` in `Mailer` (samdark)
+- Bug: Fix `Message` incompatibility with `MessageInterface` (samdark)
+- Bug: Fix not calling `Message` constructor (samdark)
 
 2.0.1 December 31, 2021
 -----------------------

--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,10 @@
         "branch-alias": {
             "dev-master": "2.0.x-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true
+        }
     }
 }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -140,29 +140,19 @@ final class Logger implements LoggerInterface
      */
     public function log($level, $message, array $context = []): void
     {
-        switch($level) {
+        switch ($level) {
+            case 'error':
+            case 'critical':
+            case 'alert':
             case 'emergency':
                 $level = \yii\log\Logger::LEVEL_ERROR;
                 break;
-            case 'alert':
-                $level = \yii\log\Logger::LEVEL_ERROR;
-                break;
-            case 'critical':
-                $level = \yii\log\Logger::LEVEL_ERROR;
-                break;
-            case 'error':
-                $level = \yii\log\Logger::LEVEL_ERROR;
-                break;
+            case 'notice':
             case 'warning':
                 $level = \yii\log\Logger::LEVEL_WARNING;
                 break;
-            case 'notice':
-                $level = \yii\log\Logger::LEVEL_WARNING;
-                break;
-            case 'info':
-                $level = \yii\log\Logger::LEVEL_INFO;
-                break;
             case 'debug':
+            case 'info':
                 $level = \yii\log\Logger::LEVEL_INFO;
                 break;
             default:

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -7,6 +7,7 @@
 
 namespace yii\symfonymailer;
 
+use RuntimeException;
 use Symfony\Component\Mailer\Mailer as SymfonyMailer;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Transport;
@@ -15,6 +16,7 @@ use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\Crypto\DkimSigner;
 use Symfony\Component\Mime\Crypto\SMimeEncrypter;
 use Symfony\Component\Mime\Crypto\SMimeSigner;
+use Yii;
 use yii\base\InvalidConfigException;
 use yii\mail\BaseMailer;
 
@@ -33,11 +35,9 @@ final class Mailer extends BaseMailer
     private $signer = null;
     private array $dkimSignerOptions = [];
     /**
-     * @var TransportInterface Symfony transport instance or its array configuration.
+     * @var TransportInterface|array Symfony transport instance or its array configuration.
      */
     private $_transport = [];
-
-
     /**
      * @var bool whether to enable writing of the Mailer internal logs using Yii log mechanism.
      * If enabled [[Logger]] plugin will be attached to the [[transport]] for this purpose.
@@ -48,7 +48,7 @@ final class Mailer extends BaseMailer
      * Creates Symfony mailer instance.
      * @return SymfonyMailer mailer instance.
      */
-    protected function createSymfonyMailer()
+    private function createSymfonyMailer(): SymfonyMailer
     {
         return new SymfonyMailer($this->getTransport());
     }
@@ -68,14 +68,14 @@ final class Mailer extends BaseMailer
      * @param array|TransportInterface $transport
      * @throws InvalidConfigException on invalid argument.
      */
-    public function setTransport($transport)
+    public function setTransport($transport): void
     {
         if (!is_array($transport) && !$transport instanceof TransportInterface) {
             throw new InvalidConfigException('"' . get_class($this) . '::transport" should be either object or array, "' . gettype($transport) . '" given.');
         }
-        if($transport instanceof TransportInterface) {
+        if ($transport instanceof TransportInterface) {
             $this->_transport = $transport;
-        } elseif(is_array($transport)) {
+        } elseif (is_array($transport)) {
             $this->_transport = $this->createTransport($transport);
         }
 
@@ -93,9 +93,9 @@ final class Mailer extends BaseMailer
         return $this->_transport;
     }
 
-    protected function createTransport(array $config = []): TransportInterface
+    private function createTransport(array $config = []): TransportInterface
     {
-        if (key_exists('enableMailerLogging', $config)) {
+        if (array_key_exists('enableMailerLogging', $config)) {
             $this->enableMailerLogging = $config['enableMailerLogging'];
             unset($config['enableMailerLogging']);
         }
@@ -108,9 +108,9 @@ final class Mailer extends BaseMailer
         $defaultFactories = Transport::getDefaultFactories(null, null, $logger);
         $transportObj = new Transport($defaultFactories);
 
-        if(key_exists('dsn', $config)) {
+        if (array_key_exists('dsn', $config)) {
             $transport = $transportObj->fromString($config['dsn']);
-        } elseif(key_exists('scheme', $config) && key_exists('host', $config)) {
+        } elseif(array_key_exists('scheme', $config) && array_key_exists('host', $config)) {
             $dsn = new Dsn(
                 $config['scheme'],
                 $config['host'],
@@ -207,7 +207,7 @@ final class Mailer extends BaseMailer
         try {
             $this->getSymfonyMailer()->send($message);
         } catch (\Exception $exception) {
-            \Yii::getLogger()->log($exception->getMessage(), \yii\log\Logger::LEVEL_ERROR, __METHOD__);
+            Yii::getLogger()->log($exception->getMessage(), \yii\log\Logger::LEVEL_ERROR, __METHOD__);
             return false;
         }
         return true;

--- a/src/Message.php
+++ b/src/Message.php
@@ -19,8 +19,9 @@ final class Message extends BaseMessage
 {
     private Email $email;
     private string $charset = 'utf-8';
-    public function __construct()
+    public function __construct($config = [])
     {
+        parent::__construct($config);
         $this->email = new Email();
     }
 
@@ -262,7 +263,7 @@ final class Message extends BaseMessage
         return 'cid:' . $file['name'];
     }
 
-    public function getHeader(string $name): array
+    public function getHeader($name): array
     {
         $headers = $this->email->getHeaders();
         if (!$headers->has($name)) {
@@ -279,13 +280,13 @@ final class Message extends BaseMessage
         return $values;
     }
 
-    public function addHeader(string $name, string $value): self
+    public function addHeader($name, $value): self
     {
         $this->email->getHeaders()->addTextHeader($name, $value);
         return $this;
     }
 
-    public function setHeader(string $name, $value): self
+    public function setHeader($name, $value): self
     {
         $headers = $this->email->getHeaders();
 
@@ -300,7 +301,7 @@ final class Message extends BaseMessage
         return $this;
     }
 
-    public function setHeaders(array $headers): self
+    public function setHeaders($headers): self
     {
         foreach ($headers as $name => $value) {
             $this->setHeader($name, $value);


### PR DESCRIPTION
…`Message` incompatibility with `MessageInterface`, Fix not calling `Message` constructor

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #17
