### PR TITLE
chore: remove unnecessary dependency on the Symfony mailer class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Symfony mailer extension Change Log
 
 - Enh #45: Added option to create transport from Dsn object (Swanty)
 - Enh #50: Forward transport logs to the Yii Logger (sammousa) 
+- Enh #49: Removed dependency on SymfonyMailer class (sammousa)
 
 
 3.0.0 December 05, 2022

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace yii\symfonymailer;
 
-use Symfony\Component\Mailer\Mailer as SymfonyMailer;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
@@ -28,8 +27,6 @@ class Mailer extends BaseMailer
      */
     public $messageClass = Message::class;
 
-
-    private ?SymfonyMailer $symfonyMailer = null;
     /**
      * @see https://symfony.com/doc/current/mailer.html#encrypting-messages
      */
@@ -44,25 +41,6 @@ class Mailer extends BaseMailer
      */
     private ?TransportInterface $_transport = null;
     public ?Transport $transportFactory = null;
-    /**
-     * Creates Symfony mailer instance.
-     * @return SymfonyMailer mailer instance.
-     */
-    private function createSymfonyMailer(): SymfonyMailer
-    {
-        return new SymfonyMailer($this->getTransport());
-    }
-
-    /**
-     * @return SymfonyMailer Swift mailer instance
-     */
-    private function getSymfonyMailer(): SymfonyMailer
-    {
-        if (!isset($this->symfonyMailer)) {
-            $this->symfonyMailer = $this->createSymfonyMailer();
-        }
-        return $this->symfonyMailer;
-    }
 
     /**
      * @param PsalmTransportConfig|TransportInterface $transport
@@ -75,8 +53,6 @@ class Mailer extends BaseMailer
         }
 
         $this->_transport = $transport instanceof TransportInterface ? $transport : $this->createTransport($transport);
-
-        $this->symfonyMailer = null;
     }
 
     private function getTransport(): TransportInterface
@@ -143,7 +119,7 @@ class Mailer extends BaseMailer
         if ($this->signer !== null) {
             $message = $this->signer->sign($message, $this->signerOptions);
         }
-        $this->getSymfonyMailer()->send($message);
+        $this->getTransport()->send($message);
         return true;
     }
 }

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -17,7 +17,6 @@ use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 use yii\mail\BaseMailer;
 use yii\psr\DynamicLogger;
-use yii\psr\Logger;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor


### PR DESCRIPTION
This removes the usage of the symfony mailer class. We did not use any of it's functionality.
We had a hard dependency on this class, but the code paths we used made it a very simple proxy. Since all usages were properly private there is no BC break.

First note the constructor of the class:
```php
    public function __construct(TransportInterface $transport, MessageBusInterface $bus = null, EventDispatcherInterface $dispatcher = null)
    {
        $this->transport = $transport;
        $this->bus = $bus;
        $this->dispatcher = $dispatcher;
    }
```
We only ever called this with 1 argument, setting the transport.

Then note the only other function, which we also only ever call with 1 argument:
```php
    public function send(RawMessage $message, Envelope $envelope = null): void
    {
        if (null === $this->bus) {
            $this->transport->send($message, $envelope);

            return;
        }
        // ... other  code omitted for brevity
   }
```
Since we never set the bus variable, we can skip this class altogether and directly have the transport send the message.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

