### PR TITLE
Feat logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,13 @@ jobs:
               uses: actions/cache@v1
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-composer-
+                  key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-${{ matrix.php }}-
             - name: Install dependencies
               run: composer update $DEFAULT_COMPOSER_FLAGS
+            - name: Install logging proxy
+              if: ${{ matrix.php != '7.4' }}
+              run: composer require "yiisoft/yii2-psr-log-source"
             - name: Run unit tests with coverage
               run: vendor/bin/phpunit --coverage-text
             - name: Static analysis (Psalm)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 Yii Framework 2 Symfony mailer extension Change Log
 ================================================
 
-3.0.1 under development
+3.1.0 under development
 -----------------------
 
 - Enh #45: Added option to create transport from Dsn object (Swanty)
+- Enh #50: Forward transport logs to the Yii Logger (sammousa) 
 
 
 3.0.0 December 05, 2022

--- a/composer.json
+++ b/composer.json
@@ -34,14 +34,23 @@
         "symplify/easy-coding-standard": "^10.1",
         "vimeo/psalm": "^4.22",
         "captainhook/captainhook": "^5.10",
-        "captainhook/plugin-composer": "^5.3"
+        "captainhook/plugin-composer": "^5.3",
+        "yiisoft/yii2-psr-log-source": "dev-feat-dynamic-logger"
+    },
+    "suggest": {
+        "yiisoft/yii2-psr-log-source": "Allows routing transport logs to your Yii2 logger"
     },
     "repositories": [
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/SamMousa/yii2-psr-log-source"
         }
     ],
+
     "autoload": {
         "psr-4": {
             "yii\\symfonymailer\\": "src"

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
         "symplify/easy-coding-standard": "^10.1",
         "vimeo/psalm": "^4.22",
         "captainhook/captainhook": "^5.10",
-        "captainhook/plugin-composer": "^5.3",
-        "yiisoft/yii2-psr-log-source": "dev-feat-dynamic-logger"
+        "captainhook/plugin-composer": "^5.3"
     },
     "suggest": {
         "yiisoft/yii2-psr-log-source": "Allows routing transport logs to your Yii2 logger"
@@ -44,13 +43,8 @@
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/SamMousa/yii2-psr-log-source"
         }
     ],
-
     "autoload": {
         "psr-4": {
             "yii\\symfonymailer\\": "src"

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -16,6 +16,8 @@ use Yii;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 use yii\mail\BaseMailer;
+use yii\psr\DynamicLogger;
+use yii\psr\Logger;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor
@@ -93,7 +95,8 @@ class Mailer extends BaseMailer
         if (isset($this->transportFactory)) {
             return $this->transportFactory;
         }
-        $defaultFactories = Transport::getDefaultFactories();
+        $logger = class_exists(DynamicLogger::class) ? new DynamicLogger() : null;
+        $defaultFactories = Transport::getDefaultFactories(null, null, $logger);
         /** @psalm-suppress InvalidArgument Symfony's type annotation is wrong */
         return new Transport($defaultFactories);
     }

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -98,6 +98,9 @@ class Mailer extends BaseMailer
         }
         /** @var LoggerInterface|null $logger */
         $logger = class_exists(DynamicLogger::class) ? new DynamicLogger() : null;
+        /**
+         * @psalm-suppress TooManyArguments On PHP 7.4 symfony/mailer 5.4 is uses which uses func_get_args instead of real args
+         */
         $defaultFactories = Transport::getDefaultFactories(null, null, $logger);
         /** @psalm-suppress InvalidArgument Symfony's type annotation is wrong */
         return new Transport($defaultFactories);

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace yii\symfonymailer;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Mailer as SymfonyMailer;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Transport\Dsn;
@@ -95,6 +96,7 @@ class Mailer extends BaseMailer
         if (isset($this->transportFactory)) {
             return $this->transportFactory;
         }
+        /** @var LoggerInterface|null $logger */
         $logger = class_exists(DynamicLogger::class) ? new DynamicLogger() : null;
         $defaultFactories = Transport::getDefaultFactories(null, null, $logger);
         /** @psalm-suppress InvalidArgument Symfony's type annotation is wrong */


### PR DESCRIPTION
Implements logging to the Yii logs if the proxy adapter is installed.
I chose to not add the proxy as a hard dependency since it requires php >= 8 whereas this library does not.
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #26 
