### PR TITLE
feat: proxy transport events to events on the mailer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Symfony mailer extension Change Log
 3.1.0 under development
 -----------------------
 
+- Enh #52: Forward events to the Yii event system (sammousa)
 - Enh #45: Added option to create transport from Dsn object (Swanty)
 - Enh #50: Forward transport logs to the Yii Logger (sammousa) 
 - Enh #49: Removed dependency on SymfonyMailer class (sammousa)

--- a/src/EventDispatcherProxy.php
+++ b/src/EventDispatcherProxy.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\symfonymailer;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use yii\base\Component;
+
+final class EventDispatcherProxy implements EventDispatcherInterface
+{
+    private Component $component;
+    public function __construct(Component  $component)
+    {
+        $this->component = $component;
+    }
+
+    public function dispatch(object $event): object
+    {
+        $this->component->trigger(get_class($event), new PsrEvent($event));
+        return $event;
+    }
+}

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -93,6 +93,7 @@ class Mailer extends BaseMailer
         if (isset($this->transportFactory)) {
             return $this->transportFactory;
         }
+        /** @psalm-suppress TooManyArguments function uses func_get_args */
         $defaultFactories = Transport::getDefaultFactories(new EventDispatcherProxy($this));
         /** @psalm-suppress InvalidArgument Symfony's type annotation is wrong */
         return new Transport($defaultFactories);

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -93,7 +93,7 @@ class Mailer extends BaseMailer
         if (isset($this->transportFactory)) {
             return $this->transportFactory;
         }
-        $defaultFactories = Transport::getDefaultFactories();
+        $defaultFactories = Transport::getDefaultFactories(new EventDispatcherProxy($this));
         /** @psalm-suppress InvalidArgument Symfony's type annotation is wrong */
         return new Transport($defaultFactories);
     }

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -76,7 +76,7 @@ class Mailer extends BaseMailer
         /**
          * @psalm-suppress TooManyArguments On PHP 7.4 symfony/mailer 5.4 is uses which uses func_get_args instead of real args
          */
-        $defaultFactories = Transport::getDefaultFactories(null, null, $logger);
+        $defaultFactories = Transport::getDefaultFactories(new EventDispatcherProxy($this), null, $logger);
         /** @psalm-suppress InvalidArgument Symfony's type annotation is wrong */
         return new Transport($defaultFactories);
     }

--- a/src/PsrEvent.php
+++ b/src/PsrEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\symfonymailer;
+
+use yii\base\Event;
+
+/**
+ * This class wraps a PSR-14 event object. Note that PSR-14 does not place any demands on an event object.
+ * In Yii all events are stoppable, in PSR-14 this is not the case. For this implementation we force all events to be
+ * stoppable
+ */
+final class PsrEvent extends Event
+{
+    private object $originalEvent;
+
+    public function __construct(object $originalEvent)
+    {
+        parent::__construct([]);
+        $this->name = get_class($originalEvent);
+        $this->originalEvent = $originalEvent;
+    }
+
+    public function getOriginalEvent(): object
+    {
+        return $this->originalEvent;
+    }
+}


### PR DESCRIPTION
This implements a proxy for forwarding PSR-14 events to Yii2 components.
This is a WIP and I'd like discuss how the code works and how we should release it.
It is probably cleanest do put this in a separate library similar to https://github.com/yiisoft/yii2-psr-log-source

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #42
