### PR TITLE
Drop support for php < 8.1 update dev dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,5 +40,7 @@ jobs:
               run: vendor/bin/phpunit --coverage-text
             - name: Static analysis (Psalm)
               run: vendor/bin/psalm
+            - name: Static analysis (phpstan)
+              run: vendor/bin/phpstan
             - name: Test code style
               run: vendor/bin/ecs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: ['7.4', '8.0', '8.1']
+                php: ['8.1', '8.2']
 
         steps:
             - name: Install sendmail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Yii Framework 2 Symfony mailer extension Change Log
 ================================================
 
+4.0.0 
+------
+ 
+- Include logger proxy as a dependency
+- Drop support for end-of-life php versions 7.4 and 8.0
+
 3.0.1 under development
 -----------------------
 

--- a/captainhook.json
+++ b/captainhook.json
@@ -29,6 +29,11 @@
                 "action": "vendor/bin/psalm",
                 "options": [],
                 "conditions": []
+            },
+            {
+                "action": "vendor/bin/phpstan",
+                "options": [],
+                "conditions": []
             }
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,14 @@
         }
     ],
     "require": {
-        "php": ">=7.4.0",
+        "php": ">=8.1",
         "yiisoft/yii2": ">=2.0.4",
         "symfony/mailer": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.5.10",
-        "symplify/easy-coding-standard": "^10.1",
-        "vimeo/psalm": "^4.22",
+        "phpunit/phpunit": "^10",
+        "symplify/easy-coding-standard": "^10",
+        "vimeo/psalm": "^5",
         "captainhook/captainhook": "^5.10",
         "captainhook/plugin-composer": "^5.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "symplify/easy-coding-standard": "^10",
         "vimeo/psalm": "^5",
         "captainhook/captainhook": "^5.10",
-        "captainhook/plugin-composer": "^5.3"
+        "captainhook/plugin-composer": "^5.3",
+        "phpstan/phpstan": "^1.9"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.1",
         "yiisoft/yii2": ">=2.0.4",
-        "symfony/mailer": ">=5.4.0"
+        "symfony/mailer": ">=6"
     },
     "require-dev": {
         "phpunit/phpunit": "^10",

--- a/ecs.php
+++ b/ecs.php
@@ -27,7 +27,7 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->rule(NoUnusedImportsFixer::class);
     $ecsConfig->rule(DeclareStrictTypesFixer::class);
     $ecsConfig->ruleWithConfiguration(FinalInternalClassFixer::class, [
-        'annotation_exclude' => ['@not-fix'],
+        'annotation_exclude' => ['@extendable'],
         'annotation_include' => [],
         'consider_absent_docblock_as_internal_class' => \true
     ]);

--- a/ecs.php
+++ b/ecs.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use PhpCsFixer\Fixer\ClassNotation\FinalInternalClassFixer;
+use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
@@ -20,6 +23,13 @@ return static function (ECSConfig $ecsConfig): void {
 
     $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [
         'syntax' => 'short'
+    ]);
+    $ecsConfig->rule(NoUnusedImportsFixer::class);
+    $ecsConfig->rule(DeclareStrictTypesFixer::class);
+    $ecsConfig->ruleWithConfiguration(FinalInternalClassFixer::class, [
+        'annotation_exclude' => ['@not-fix'],
+        'annotation_include' => [],
+        'consider_absent_docblock_as_internal_class' => \true
     ]);
 
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+  level: 9
+  paths:
+    - src
+    - tests
+  treatPhpDocTypesAsCertain: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,4 @@ parameters:
   level: 9
   paths:
     - src
-    - tests
   treatPhpDocTypesAsCertain: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="./tests/bootstrap.php"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         forceCoversAnnotation="true"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Yii2-swiftmailer Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" colors="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true">
+  <testsuites>
+    <testsuite name="Yii2-swiftmailer Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" colors="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" colors="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true">
   <testsuites>
     <testsuite name="Yii2-swiftmailer Test Suite">
       <directory>./tests</directory>
     </testsuite>
   </testsuites>
-  <coverage>
+  <source>
     <include>
       <directory suffix=".php">src</directory>
     </include>
-  </coverage>
+  </source>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/DkimMessageSigner.php
+++ b/src/DkimMessageSigner.php
@@ -14,7 +14,7 @@ use Symfony\Component\Mime\Message;
 /**
  * @codeCoverageIgnore This class is a trivial proxy that requires no testing
  */
-class DkimMessageSigner implements MessageSignerInterface
+final class DkimMessageSigner implements MessageSignerInterface
 {
     private DkimSigner $dkimSigner;
     public function __construct(DkimSigner $dkimSigner)

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -12,7 +12,6 @@ use Symfony\Component\Mailer\Mailer as SymfonyMailer;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
-use Yii;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 use yii\mail\BaseMailer;
@@ -21,6 +20,7 @@ use yii\mail\BaseMailer;
  * @psalm-suppress PropertyNotSetInConstructor
  * @psalm-type TransportConfigArray array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array<mixed>, dsn?:string|Dsn }
  * @phpstan-type TransportConfigArray array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array<mixed>, dsn?:string|Dsn }
+ * @not-fix
  */
 class Mailer extends BaseMailer
 {

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -19,7 +19,7 @@ use yii\psr\DynamicLogger;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor
- * @psalm-type TransportConfigArray array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array<mixed>, dsn?:string|Dsn }
+ * @psalm-type TransportHostArray array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array<mixed>, dsn?:string|Dsn }
  * @phpstan-type TransportConfigArray array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array<mixed>, dsn?:string|Dsn }
  * @extendable
  */
@@ -88,10 +88,12 @@ class Mailer extends BaseMailer
     private function createTransport(array $config = []): TransportInterface
     {
         $transportFactory = $this->getTransportFactory();
-        if (array_key_exists('dsn', $config) && is_string($config['dsn'])) {
-            $transport = $transportFactory->fromString($config['dsn']);
-        } elseif (array_key_exists('dsn', $config) && $config['dsn'] instanceof Dsn) {
-            $transport = $transportFactory->fromDsnObject($config['dsn']);
+        if (array_key_exists('dsn', $config)) {
+            if (is_string($config['dsn'])) {
+                $transport = $transportFactory->fromString($config['dsn']);
+            } else {
+                $transport = $transportFactory->fromDsnObject($config['dsn']);
+            }
         } elseif (array_key_exists('scheme', $config) && array_key_exists('host', $config)) {
             $dsn = new Dsn(
                 $config['scheme'],

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -73,9 +73,6 @@ class Mailer extends BaseMailer
         }
         /** @var LoggerInterface|null $logger */
         $logger = class_exists(DynamicLogger::class) ? new DynamicLogger() : null;
-        /**
-         * @psalm-suppress TooManyArguments On PHP 7.4 symfony/mailer 5.4 is uses which uses func_get_args instead of real args
-         */
         $defaultFactories = Transport::getDefaultFactories(new EventDispatcherProxy($this), null, $logger);
         /** @psalm-suppress InvalidArgument Symfony's type annotation is wrong */
         return new Transport($defaultFactories);

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -20,7 +20,7 @@ use yii\mail\BaseMailer;
  * @psalm-suppress PropertyNotSetInConstructor
  * @psalm-type TransportConfigArray array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array<mixed>, dsn?:string|Dsn }
  * @phpstan-type TransportConfigArray array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array<mixed>, dsn?:string|Dsn }
- * @not-fix
+ * @extendable
  */
 class Mailer extends BaseMailer
 {

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -19,7 +19,8 @@ use yii\mail\BaseMailer;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor
- * @psalm-type PsalmTransportConfig array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array, dsn?:string|Dsn }
+ * @psalm-type TransportConfigArray array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array<mixed>, dsn?:string|Dsn }
+ * @phpstan-type TransportConfigArray array{scheme?:string, host?:string, username?:string, password?:string, port?:int, options?: array<mixed>, dsn?:string|Dsn }
  */
 class Mailer extends BaseMailer
 {
@@ -38,6 +39,9 @@ class Mailer extends BaseMailer
      * @see https://symfony.com/doc/current/mailer.html#signing-messages
      */
     public ?MessageSignerInterface $signer = null;
+    /**
+     * @var array<mixed>
+     */
     public array $signerOptions = [];
     /**
      * @var null|TransportInterface Symfony transport instance or its array configuration.
@@ -65,15 +69,11 @@ class Mailer extends BaseMailer
     }
 
     /**
-     * @param PsalmTransportConfig|TransportInterface $transport
+     * @param TransportConfigArray|TransportInterface $transport
      * @throws InvalidConfigException on invalid argument.
      */
-    public function setTransport($transport): void
+    public function setTransport(array|TransportInterface $transport): void
     {
-        if (!is_array($transport) && !$transport instanceof TransportInterface) {
-            throw new InvalidArgumentException('"' . get_class($this) . '::transport" should be either object or array, "' . gettype($transport) . '" given.');
-        }
-
         $this->_transport = $transport instanceof TransportInterface ? $transport : $this->createTransport($transport);
 
         $this->symfonyMailer = null;
@@ -99,7 +99,7 @@ class Mailer extends BaseMailer
     }
 
     /**
-     * @param PsalmTransportConfig $config
+     * @param TransportConfigArray $config
      * @throws InvalidConfigException
      */
     private function createTransport(array $config = []): TransportInterface

--- a/src/Message.php
+++ b/src/Message.php
@@ -28,6 +28,10 @@ class Message extends BaseMessage implements MessageWrapperInterface
 {
     private Email $email;
     private string $charset = 'utf-8';
+
+    /**
+     * @param array<string, mixed> $config
+     */
     public function __construct(array $config = [])
     {
         $this->email = new Email();
@@ -55,23 +59,32 @@ class Message extends BaseMessage implements MessageWrapperInterface
         return $this;
     }
 
-    public function getFrom()
+    /**
+     * @psalm-suppress ArgumentTypeCoercion Symfony typehint is too loose
+     * @return array<string, string>|string
+     */
+    public function getFrom(): array|string
     {
         return $this->convertAddressesToStrings($this->email->getFrom());
     }
 
     /**
      * @param array<int|string, string>|string $from
-     * @psalm-suppress MoreSpecificImplementedParamType
-     * @psalm-suppress LessSpecificImplementedReturnType
+     * @psalm-suppress MoreSpecificImplementedParamType Yii typehint is too loose
+     * @psalm-suppress ArgumentTypeCoercion Symfony typehint is too loose
+     * @return $this
      */
-    public function setFrom($from): self
+    public function setFrom($from): static
     {
         $this->email->from(...$this->convertStringsToAddresses($from));
         return $this;
     }
 
-    public function getTo()
+    /**
+     * @psalm-suppress ArgumentTypeCoercion Symfony typehint is too loose
+     * @return array<string, string>|string
+     */
+    public function getTo(): array|string
     {
         return $this->convertAddressesToStrings($this->email->getTo());
     }
@@ -87,6 +100,10 @@ class Message extends BaseMessage implements MessageWrapperInterface
         return $this;
     }
 
+    /**
+     * @psalm-suppress ArgumentTypeCoercion Symfony typehint is too loose
+     * @return array<string, string>|string
+     */
     public function getReplyTo()
     {
         return $this->convertAddressesToStrings($this->email->getReplyTo());
@@ -103,7 +120,11 @@ class Message extends BaseMessage implements MessageWrapperInterface
         return $this;
     }
 
-    public function getCc()
+    /**
+     * @psalm-suppress ArgumentTypeCoercion Symfony typehint is too loose
+     * @return array<string,string>|string
+     */
+    public function getCc(): array|string
     {
         return $this->convertAddressesToStrings($this->email->getCc());
     }
@@ -119,7 +140,11 @@ class Message extends BaseMessage implements MessageWrapperInterface
         return $this;
     }
 
-    public function getBcc()
+    /**
+     * @psalm-suppress ArgumentTypeCoercion Symfony typehint is too loose
+     * @return array<string, string>|string
+     */
+    public function getBcc(): array|string
     {
         return $this->convertAddressesToStrings($this->email->getBcc());
     }
@@ -262,6 +287,9 @@ class Message extends BaseMessage implements MessageWrapperInterface
         return 'cid:' . $options['fileName'];
     }
 
+    /**
+     * @return list<string>
+     */
     public function getHeader(string $name): array
     {
         $headers = $this->email->getHeaders();
@@ -285,7 +313,7 @@ class Message extends BaseMessage implements MessageWrapperInterface
     /**
      * @param string|list<string> $value
      */
-    public function setHeader(string $name, $value): self
+    public function setHeader(string $name, array|string $value): self
     {
         $headers = $this->email->getHeaders();
 
@@ -329,11 +357,11 @@ class Message extends BaseMessage implements MessageWrapperInterface
     /**
      * Converts address instances to their string representations.
      *
-     * @param Address[] $addresses
+     * @param list<Address> $addresses
      *
      * @return array<string, string>|string
      */
-    private function convertAddressesToStrings(array $addresses)
+    private function convertAddressesToStrings(array $addresses): string|array
     {
         $strings = [];
 
@@ -349,9 +377,9 @@ class Message extends BaseMessage implements MessageWrapperInterface
      *
      * @param array<int|string, string>|string $strings
      *
-     * @return Address[]
+     * @return list<Address>
      */
-    private function convertStringsToAddresses($strings): array
+    private function convertStringsToAddresses(array|string $strings): array
     {
         $addresses = [];
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -284,7 +284,7 @@ class Message extends BaseMessage implements MessageWrapperInterface
      */
     public function embedContent($content, array $options = []): string
     {
-        if (empty($options['fileName'])) {
+        if (!isset($options['fileName'])) {
             throw new InvalidConfigException('A valid file name must be passed when embedding content');
         }
         $this->email->embed($content, $options['fileName'], $options['contentType'] ?? null);

--- a/src/Message.php
+++ b/src/Message.php
@@ -26,7 +26,7 @@ use yii\mail\BaseMessage;
  * @property PsalmAddressList $bcc The type defined by the message interface is not strict enough.
  * @property-read Email $symfonyEmail Symfony email instance.
  *
- * @not-fix This class may be extended by library users
+ * @extendable
  */
 class Message extends BaseMessage implements MessageWrapperInterface
 {

--- a/src/Message.php
+++ b/src/Message.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -23,6 +25,8 @@ use yii\mail\BaseMessage;
  *
  * @property PsalmAddressList $bcc The type defined by the message interface is not strict enough.
  * @property-read Email $symfonyEmail Symfony email instance.
+ *
+ * @not-fix This class may be extended by library users
  */
 class Message extends BaseMessage implements MessageWrapperInterface
 {

--- a/src/MessageSignerInterface.php
+++ b/src/MessageSignerInterface.php
@@ -12,5 +12,8 @@ use Symfony\Component\Mime\Message;
 
 interface MessageSignerInterface
 {
+    /**
+     * @param array<mixed> $options
+     */
     public function sign(Message $message, array $options = []): Message;
 }

--- a/src/SMimeMessageEncrypter.php
+++ b/src/SMimeMessageEncrypter.php
@@ -14,12 +14,10 @@ use Symfony\Component\Mime\Message;
 /**
  * @codeCoverageIgnore This class is a trivial proxy that requires no testing
  */
-class SMimeMessageEncrypter implements MessageEncrypterInterface
+final class SMimeMessageEncrypter implements MessageEncrypterInterface
 {
-    private SMimeEncrypter $encrypter;
-    public function __construct(SMimeEncrypter $encrypter)
+    public function __construct(private readonly SMimeEncrypter $encrypter)
     {
-        $this->encrypter = $encrypter;
     }
 
     public function encrypt(Message $message): Message

--- a/src/SMimeMessageSigner.php
+++ b/src/SMimeMessageSigner.php
@@ -14,12 +14,10 @@ use Symfony\Component\Mime\Message;
 /**
  * @codeCoverageIgnore This class is a trivial proxy that requires no testing
  */
-class SMimeMessageSigner implements MessageSignerInterface
+final class SMimeMessageSigner implements MessageSignerInterface
 {
-    private SMimeSigner $signer;
-    public function __construct(SMimeSigner $signer)
+    public function __construct(private readonly SMimeSigner $signer)
     {
-        $this->signer = $signer;
     }
 
     public function sign(Message $message, array $options = []): Message

--- a/tests/MailerTest.php
+++ b/tests/MailerTest.php
@@ -158,13 +158,6 @@ final class MailerTest extends TestCase
         ]);
     }
 
-    public function testSetTransportWithInvalidArgumentThrowsException(): void
-    {
-        $mailer = new Mailer();
-        $this->expectException(InvalidArgumentException::class);
-        $mailer->setTransport(new \stdClass());
-    }
-
     public function testSendMessageThrowsOnBadMessageType(): void
     {
         $mailer = new Mailer();

--- a/tests/MailerTest.php
+++ b/tests/MailerTest.php
@@ -6,7 +6,6 @@ namespace yiiunit\extensions\symfonymailer;
 
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
-use Symfony\Component\Mime\Crypto\SMimeEncrypter;
 use Yii;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace yiiunit\extensions\symfonymailer;
 
 use yii\helpers\ArrayHelper;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // ensure we get report on all possible php errors
 error_reporting(-1);
 

--- a/tests/compatibility.php
+++ b/tests/compatibility.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /*
  * Ensures compatibility with PHPUnit < 6.x
  */


### PR DESCRIPTION
Work in progress, blocked by some other PRs.

- [x] Add the logger proxy dependency as a dependency of this library after https://github.com/yiisoft/yii2-psr-log-source/pull/8 is merged and released -- it's a suggestion, which is good.
- [x] Add typed parameters and return types using union types
- [x] Improve phpdoc types
- [x] Enforce `declare(strict_types=1)`
- [x] Enforce classes to be final unless annotated with `@extendable`
- [x] Add phpstan


| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #53 
