### PR TITLE
Make message class inheritable again

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -26,8 +26,8 @@ use yii\mail\BaseMessage;
  */
 class Message extends BaseMessage implements MessageWrapperInterface
 {
-    private Email $email;
-    private string $charset = 'utf-8';
+    protected Email $email;
+    protected string $charset = 'utf-8';
     public function __construct(array $config = [])
     {
         $this->email = new Email();


### PR DESCRIPTION
Some key properties of the class Message are private preventing any proper inheritance. 
Open them up by making them protected

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #58
