### PR TITLE
serialize(): "email" returned as member variable from __sleep() but does not exist

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -30,8 +30,8 @@ use yii\mail\BaseMessage;
  */
 class Message extends BaseMessage implements MessageWrapperInterface
 {
-    private Email $email;
-    private string $charset = 'utf-8';
+    protected Email $email;
+    protected string $charset = 'utf-8';
 
     /**
      * @param array<string, mixed> $config


### PR DESCRIPTION
Исключение 

serialize(): "email" returned as member variable from __sleep() but does not exist

При сериализации объекта src/Message.php метод __sleep возвращает массив свойств которые являются приватными .

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
