### PR TITLE
Add support for Azure Email Communication Services.

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,6 +1,7 @@
 {
     "symbol-whitelist": [
         "Symfony\\Component\\Mailer\\Bridge\\Amazon\\Transport\\SesTransportFactory",
+        "Symfony\\Component\\Mailer\\Bridge\\Azure\\Transport\\AzureTransportFactory",
         "Symfony\\Component\\Mailer\\Bridge\\Google\\Transport\\GmailTransportFactory",
         "Symfony\\Component\\Mailer\\Bridge\\Infobip\\Transport\\InfobipTransportFactory",
         "Symfony\\Component\\Mailer\\Bridge\\Mailchimp\\Transport\\MandrillTransportFactory",

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mailer\Transport\SendmailTransportFactory;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesTransportFactory;
+use Symfony\Component\Mailer\Bridge\Azure\Transport\AzureTransportFactory;
 use Symfony\Component\Mailer\Bridge\Google\Transport\GmailTransportFactory;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillTransportFactory;
@@ -103,6 +104,7 @@ class Mailer extends BaseMailer
                 EsmtpTransportFactory::class,
                 NativeTransportFactory::class,
                 SesTransportFactory::class,
+                AzureTransportFactory::class,
                 GmailTransportFactory::class,
                 InfobipTransportFactory::class,
                 MandrillTransportFactory::class,


### PR DESCRIPTION
`Mailer.php::getTransportFactory()` does not include AzureTransportFactory::class, and this causes `azure+api` dsn to fail. `AzureTransportFactory::class` is already present in the `symfony/mailer` package's `Transport::getDefaultFactories()` list since 7.1.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | None
