### PR TITLE
Support Symfony Mailer v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 Symfony mailer extension Change Log
 
 - Enh #80: Add support for Azure Email Communication Services (bijoys)
 - Enh #81: Remove unnecessary files from Composer package (@s1lver)
+- Ehn #84: Add support for Symfony Mailer v8 (rntluca)
 
 4.0.0 Jan 29, 2024
 ------------------

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     "require": {
         "php": ">=8.1",
         "psr/event-dispatcher": "^1.0",
-        "symfony/mailer": "^6.4 || ^7.0",
-        "symfony/mime": "^6.4 || ^7.0",
+        "symfony/mailer": "^6.4 || ^7.0 || ^8.0",
+        "symfony/mime": "^6.4 || ^7.0 || ^8.0",
         "yiisoft/yii2": ">=2.0.4"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Symfony 8 has been available since November 2025. 
This PR aims to add support for the new v8 versions of the packages:

- symfony/mailer
- symfony/mime