### PR TITLE
Remove Codecov failure override

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      codecovFailCiIfError: false
       composer-command: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi --ignore-platform-req=php+
       os: >-
         ['ubuntu-latest']


### PR DESCRIPTION
Removes the explicit codecovFailCiIfError override from the PHPUnit workflow so the shared workflow default is used. Validation: git diff --check.